### PR TITLE
Fix GPUImageContext leak in movie writer

### DIFF
--- a/framework/Source/iOS/GPUImageMovieWriter.m
+++ b/framework/Source/iOS/GPUImageMovieWriter.m
@@ -101,8 +101,7 @@ static BOOL synchronizedSetInputFramebuffer = YES;
     previousAudioTime = kCMTimeNegativeInfinity;
     inputRotation = kGPUImageNoRotation;
     
-    _movieWriterContext = [[GPUImageContext alloc] init];
-    [_movieWriterContext useSharegroup:[[[GPUImageContext sharedImageProcessingContext] context] sharegroup]];
+    _movieWriterContext = [GPUImageContext sharedImageProcessingContext];
 
     runSynchronouslyOnContextQueue(_movieWriterContext, ^{
         [_movieWriterContext useAsCurrentContext];


### PR DESCRIPTION
Leak identified in Instruments and some googling led to this:
http://stackoverflow.com/questions/27857330/memory-leak-occurs-when-use-gpuimagemoviewriter-multiple-times
